### PR TITLE
Fixed NullReferenceException

### DIFF
--- a/DesktopDuplication/DesktopDuplicator.cs
+++ b/DesktopDuplication/DesktopDuplicator.cs
@@ -166,6 +166,8 @@ namespace DesktopDuplication
                     throw new DesktopDuplicationException("Failed to acquire next frame.");
                 }
             }
+            if (desktopResource == null)
+                return false;
             using (var tempTexture = desktopResource.QueryInterface<Texture2D>())
                 mDevice.ImmediateContext.CopyResource(tempTexture, desktopImageTexture);
             desktopResource.Dispose();


### PR DESCRIPTION
Usually happens when switching between desktop and DirectX apps. It could cause significant memory leaks if it happens every frame.